### PR TITLE
Initial classes

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <option name="LINE_SEPARATOR" value="&#10;" />
+        <PHPCodeStyleSettings>
+          <option name="ALIGN_KEY_VALUE_PAIRS" value="true" />
+          <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
+          <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
+          <option name="ALIGN_ASSIGNMENTS" value="true" />
+          <option name="COMMA_AFTER_LAST_ARRAY_ELEMENT" value="true" />
+          <option name="PHPDOC_BLANK_LINE_BEFORE_TAGS" value="true" />
+          <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
+          <option name="PHPDOC_WRAP_LONG_LINES" value="true" />
+          <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />
+          <option name="LOWER_CASE_NULL_CONST" value="true" />
+          <option name="ELSE_IF_STYLE" value="COMBINE" />
+          <option name="VARIABLE_NAMING_STYLE" value="CAMEL_CASE" />
+          <option name="BLANK_LINE_BEFORE_RETURN_STATEMENT" value="true" />
+          <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
+          <option name="BLANK_LINES_AROUND_CONSTANTS" value="1" />
+          <option name="BLANK_LINES_AFTER_OPENING_TAG" value="1" />
+          <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="1" />
+          <option name="SPACE_BETWEEN_TERNARY_QUEST_AND_COLON" value="true" />
+          <option name="SPACE_BEFORE_CLOSURE_LEFT_PARENTHESIS" value="false" />
+          <option name="FORCE_SHORT_DECLARATION_ARRAY_STYLE" value="true" />
+          <option name="SPACE_BEFORE_COLON_IN_RETURN_TYPE" value="true" />
+          <option name="NAMESPACE_BRACE_STYLE" value="2" />
+          <option name="PLACE_PARENS_FOR_CONSTRUCTOR" value="1" />
+        </PHPCodeStyleSettings>
+        <codeStyleSettings language="JSON">
+          <indentOptions>
+            <option name="INDENT_SIZE" value="4" />
+          </indentOptions>
+        </codeStyleSettings>
+        <codeStyleSettings language="PHP">
+          <option name="RIGHT_MARGIN" value="120" />
+          <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+          <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="0" />
+          <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+          <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+          <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
+          <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+          <option name="SPECIAL_ELSE_IF_TREATMENT" value="true" />
+          <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+          <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+          <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+          <option name="ALIGN_MULTILINE_FOR" value="false" />
+          <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+          <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+          <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+          <option name="SPACE_AROUND_UNARY_OPERATOR" value="true" />
+          <option name="SPACE_AFTER_TYPE_CAST" value="true" />
+          <option name="CALL_PARAMETERS_WRAP" value="5" />
+          <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+          <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+          <option name="METHOD_PARAMETERS_WRAP" value="5" />
+          <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+          <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+          <option name="EXTENDS_LIST_WRAP" value="1" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+          <option name="PARENTHESES_EXPRESSION_LPAREN_WRAP" value="true" />
+          <option name="PARENTHESES_EXPRESSION_RPAREN_WRAP" value="true" />
+          <option name="TERNARY_OPERATION_WRAP" value="5" />
+          <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+          <option name="FOR_STATEMENT_LPAREN_ON_NEXT_LINE" value="true" />
+          <option name="FOR_STATEMENT_RPAREN_ON_NEXT_LINE" value="true" />
+          <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+          <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+          <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+          <option name="IF_BRACE_FORCE" value="3" />
+          <option name="DOWHILE_BRACE_FORCE" value="3" />
+          <option name="WHILE_BRACE_FORCE" value="3" />
+          <option name="FOR_BRACE_FORCE" value="3" />
+          <option name="WRAP_ON_TYPING" value="1" />
+          <indentOptions>
+            <option name="SMART_TABS" value="true" />
+          </indentOptions>
+          <arrangement>
+            <groups>
+              <group>
+                <type>GETTERS_AND_SETTERS</type>
+                <order>KEEP</order>
+              </group>
+              <group>
+                <type>DEPENDENT_METHODS</type>
+                <order>DEPTH_FIRST</order>
+              </group>
+              <group>
+                <type>OVERRIDDEN_METHODS</type>
+                <order>KEEP</order>
+              </group>
+            </groups>
+          </arrangement>
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>

--- a/.idea/event-state-machine.iml
+++ b/.idea/event-state-machine.iml
@@ -3,7 +3,6 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="RebelCode\State\" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/vendor" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/codeclimate/php-test-reporter" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
@@ -11,9 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/instantiator" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/friendsofphp/php-cs-fixer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/guzzle/guzzle" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-common" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-docblock" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/type-resolver" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
@@ -42,7 +39,6 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/process" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/stopwatch" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/yaml" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -51,13 +47,22 @@
         <CLASSES>
           <root url="file://$MODULE_DIR$/vendor/codeclimate/php-test-reporter" />
           <root url="file://$MODULE_DIR$/vendor/composer" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/data-key-value-aware-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception-helper-base" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/i18n-helper-base" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/i18n-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/machine-state-machine-interface" />
           <root url="file://$MODULE_DIR$/vendor/dhii/php-cs-fixer-config" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/psr-14" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/state-machine-abstract" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/stringable-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/transition-event-interface" />
           <root url="file://$MODULE_DIR$/vendor/doctrine/instantiator" />
           <root url="file://$MODULE_DIR$/vendor/friendsofphp/php-cs-fixer" />
           <root url="file://$MODULE_DIR$/vendor/guzzle/guzzle" />
-          <root url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-common" />
           <root url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-docblock" />
-          <root url="file://$MODULE_DIR$/vendor/phpdocumentor/type-resolver" />
           <root url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
           <root url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
           <root url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
@@ -86,18 +91,26 @@
           <root url="file://$MODULE_DIR$/vendor/symfony/process" />
           <root url="file://$MODULE_DIR$/vendor/symfony/stopwatch" />
           <root url="file://$MODULE_DIR$/vendor/symfony/yaml" />
-          <root url="file://$MODULE_DIR$/vendor/webmozart/assert" />
         </CLASSES>
         <SOURCES>
           <root url="file://$MODULE_DIR$/vendor/codeclimate/php-test-reporter" />
           <root url="file://$MODULE_DIR$/vendor/composer" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/data-key-value-aware-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception-helper-base" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/exception-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/i18n-helper-base" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/i18n-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/machine-state-machine-interface" />
           <root url="file://$MODULE_DIR$/vendor/dhii/php-cs-fixer-config" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/psr-14" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/state-machine-abstract" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/stringable-interface" />
+          <root url="file://$MODULE_DIR$/vendor/dhii/transition-event-interface" />
           <root url="file://$MODULE_DIR$/vendor/doctrine/instantiator" />
           <root url="file://$MODULE_DIR$/vendor/friendsofphp/php-cs-fixer" />
           <root url="file://$MODULE_DIR$/vendor/guzzle/guzzle" />
-          <root url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-common" />
           <root url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-docblock" />
-          <root url="file://$MODULE_DIR$/vendor/phpdocumentor/type-resolver" />
           <root url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
           <root url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
           <root url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
@@ -126,7 +139,6 @@
           <root url="file://$MODULE_DIR$/vendor/symfony/process" />
           <root url="file://$MODULE_DIR$/vendor/symfony/stopwatch" />
           <root url="file://$MODULE_DIR$/vendor/symfony/yaml" />
-          <root url="file://$MODULE_DIR$/vendor/webmozart/assert" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpTestFrameworkVersionCache">
+    <tools_cache>
+      <tool tool_name="PHPUnit">
+        <cache>
+          <versions>
+            <info id="Local" version="4.8.36" />
+          </versions>
+        </cache>
+      </tool>
+    </tools_cache>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -27,12 +27,9 @@
       <path value="$PROJECT_DIR$/vendor/sebastian/recursion-context" />
       <path value="$PROJECT_DIR$/vendor/sebastian/diff" />
       <path value="$PROJECT_DIR$/vendor/sebastian/version" />
-      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
       <path value="$PROJECT_DIR$/vendor/codeclimate/php-test-reporter" />
       <path value="$PROJECT_DIR$/vendor/friendsofphp/php-cs-fixer" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
-      <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
-      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-mbstring" />
       <path value="$PROJECT_DIR$/vendor/symfony/event-dispatcher" />
       <path value="$PROJECT_DIR$/vendor/symfony/console" />
@@ -40,6 +37,17 @@
       <path value="$PROJECT_DIR$/vendor/symfony/debug" />
       <path value="$PROJECT_DIR$/vendor/symfony/yaml" />
       <path value="$PROJECT_DIR$/vendor/symfony/config" />
+      <path value="$PROJECT_DIR$/vendor/dhii/machine-state-machine-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/psr-14" />
+      <path value="$PROJECT_DIR$/vendor/dhii/data-key-value-aware-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/exception-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/stringable-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/state-machine-abstract" />
+      <path value="$PROJECT_DIR$/vendor/dhii/i18n-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/i18n-helper-base" />
+      <path value="$PROJECT_DIR$/vendor/dhii/exception-helper-base" />
+      <path value="$PROJECT_DIR$/vendor/dhii/exception" />
+      <path value="$PROJECT_DIR$/vendor/dhii/transition-event-interface" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="5.4.0" />

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,20 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.4 | ^7.0"
+        "php": "^5.4 | ^7.0",
+        "dhii/machine-state-machine-interface": "dev-task/initial-interfaces",
+        "dhii/state-machine-abstract": "dev-task/initial-classes",
+        "dhii/i18n-helper-base": "dev-develop",
+        "dhii/exception-helper-base": "dev-develop",
+        "dhii/transition-event-interface": "dev-task/initial-interfaces"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "ptrofimov/xpmock": "^1.1",
         "dhii/php-cs-fixer-config": "^0.1",
-        "codeclimate/php-test-reporter": "<=0.3.2"
+        "codeclimate/php-test-reporter": "<=0.3.2",
+        "dhii/stringable-interface": "^0.1",
+        "dhii/psr-14": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -28,5 +35,19 @@
     "scripts": {
         "test": "phpunit",
         "csfix": "php-cs-fixer fix -vvv"
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/psr-14"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/state-machine-abstract"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/transition-event-interface"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.4 | ^7.0",
-        "dhii/machine-state-machine-interface": "dev-task/initial-interfaces",
+        "dhii/machine-state-machine-interface": "dev-develop",
         "dhii/state-machine-abstract": "dev-task/initial-classes",
         "dhii/i18n-helper-base": "dev-develop",
         "dhii/exception-helper-base": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9078cd773110b00eb88977ecec45dcb",
+    "content-hash": "b797da25b60f2ce4eebe055b3748d2bd",
     "packages": [
         {
             "name": "dhii/data-key-value-aware-interface",
@@ -270,16 +270,16 @@
         },
         {
             "name": "dhii/machine-state-machine-interface",
-            "version": "dev-task/initial-interfaces",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/machine-state-machine-interface.git",
-                "reference": "a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801"
+                "reference": "6e7d5b507a9935c929720da558a600bfb0202b41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/machine-state-machine-interface/zipball/a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801",
-                "reference": "a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801",
+                "url": "https://api.github.com/repos/Dhii/machine-state-machine-interface/zipball/6e7d5b507a9935c929720da558a600bfb0202b41",
+                "reference": "6e7d5b507a9935c929720da558a600bfb0202b41",
                 "shasum": ""
             },
             "require": {
@@ -311,7 +311,7 @@
                 }
             ],
             "description": "Interfaces for state machines.",
-            "time": "2017-09-28 11:47:00"
+            "time": "2017-10-01 15:47:53"
         },
         {
             "name": "dhii/psr-14",
@@ -453,16 +453,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/transition-event-interface.git",
-                "reference": "4c9da633f3500bfe8350c7c662e103c398515de4"
+                "reference": "cfde8db15735a11e2d05c1c784795cc5073b44f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/transition-event-interface/zipball/4c9da633f3500bfe8350c7c662e103c398515de4",
-                "reference": "4c9da633f3500bfe8350c7c662e103c398515de4",
+                "url": "https://api.github.com/repos/Dhii/transition-event-interface/zipball/cfde8db15735a11e2d05c1c784795cc5073b44f8",
+                "reference": "cfde8db15735a11e2d05c1c784795cc5073b44f8",
                 "shasum": ""
             },
             "require": {
-                "dhii/machine-state-machine-interface": "dev-task/initial-interfaces",
+                "dhii/machine-state-machine-interface": "dev-develop",
                 "dhii/psr-14": "dev-master",
                 "php": "^5.3 | ^7.0"
             },
@@ -501,7 +501,7 @@
                 "source": "https://github.com/Dhii/transition-event-interface/tree/task/initial-interfaces",
                 "issues": "https://github.com/Dhii/transition-event-interface/issues"
             },
-            "time": "2017-09-29 16:17:00"
+            "time": "2017-10-10 12:18:11"
         }
     ],
     "packages-dev": [
@@ -1812,16 +1812,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe"
+                "reference": "1dbeaa8e2db4b29159265867efff075ad961558c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0b8541d18507d10204a08384640ff6df3c739ebe",
-                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe",
+                "url": "https://api.github.com/repos/symfony/config/zipball/1dbeaa8e2db4b29159265867efff075ad961558c",
+                "reference": "1dbeaa8e2db4b29159265867efff075ad961558c",
                 "shasum": ""
             },
             "require": {
@@ -1864,20 +1864,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:07:15+00:00"
+            "time": "2017-10-04T18:56:36+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253"
+                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c0807a2ca978e64d8945d373a9221a5c35d1a253",
-                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
+                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
                 "shasum": ""
             },
             "require": {
@@ -1925,20 +1925,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27T14:29:03+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752"
+                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/efc9656dcb227e1459905d5aa51e43dfec76e752",
-                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/eaaec993ca5e8067e204b2ee653cdd142961f33e",
+                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e",
                 "shasum": ""
             },
             "require": {
@@ -1982,20 +1982,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27T14:29:03+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d"
+                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1377400fd641d7d1935981546aaef780ecd5bf6d",
-                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7fe089232554357efb8d4af65ce209fc6e5a2186",
+                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186",
                 "shasum": ""
             },
             "require": {
@@ -2042,20 +2042,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T07:47:27+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2"
+                "reference": "5e3af878f144089faddd4060a48cadae4fc44dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/714b1036010c354ae2b25d7f9ca27e14e265e9f2",
-                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5e3af878f144089faddd4060a48cadae4fc44dee",
+                "reference": "5e3af878f144089faddd4060a48cadae4fc44dee",
                 "shasum": ""
             },
             "require": {
@@ -2091,20 +2091,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-11T07:12:11+00:00"
+            "time": "2017-10-02T08:46:46+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad"
+                "reference": "a945724b201f74d543e356f6059c930bb8d10c92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
-                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a945724b201f74d543e356f6059c930bb8d10c92",
+                "reference": "a945724b201f74d543e356f6059c930bb8d10c92",
                 "shasum": ""
             },
             "require": {
@@ -2140,7 +2140,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T20:52:29+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2203,16 +2203,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8"
+                "reference": "26c9fb02bf06bd6b90f661a5bd17e510810d0176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
-                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/26c9fb02bf06bd6b90f661a5bd17e510810d0176",
+                "reference": "26c9fb02bf06bd6b90f661a5bd17e510810d0176",
                 "shasum": ""
             },
             "require": {
@@ -2248,20 +2248,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-03T08:04:30+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "e02577b841394a78306d7b547701bb7bb705bad5"
+                "reference": "28ee62ea4736431ca817cdaebcb005663e9cd1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e02577b841394a78306d7b547701bb7bb705bad5",
-                "reference": "e02577b841394a78306d7b547701bb7bb705bad5",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/28ee62ea4736431ca817cdaebcb005663e9cd1cb",
+                "reference": "28ee62ea4736431ca817cdaebcb005663e9cd1cb",
                 "shasum": ""
             },
             "require": {
@@ -2297,20 +2297,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:07:15+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5"
+                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
-                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/842fb6df22180244b4c65935ce1a88d324e5ff9e",
+                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e",
                 "shasum": ""
             },
             "require": {
@@ -2346,7 +2346,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T20:52:29+00:00"
+            "time": "2017-10-05T14:38:30+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,506 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e19c46a4640cc4ab404ecd5070dec35",
-    "packages": [],
+    "content-hash": "f9078cd773110b00eb88977ecec45dcb",
+    "packages": [
+        {
+            "name": "dhii/data-key-value-aware-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/data-key-value-aware-interface.git",
+                "reference": "220232bc9040fab78a6c039f5a4a5f9542317bdc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/data-key-value-aware-interface/zipball/220232bc9040fab78a6c039f5a4a5f9542317bdc",
+                "reference": "220232bc9040fab78a6c039f5a4a5f9542317bdc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "4.*",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Data\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces that aim to increase interoperability of value objects",
+            "time": "2017-01-21T17:35:30+00:00"
+        },
+        {
+            "name": "dhii/exception",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/exception.git",
+                "reference": "160d0f5086982fe43d963ea9a1c60c3c2bdf4169"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/exception/zipball/160d0f5086982fe43d963ea9a1c60c3c2bdf4169",
+                "reference": "160d0f5086982fe43d963ea9a1c60c3c2bdf4169",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/exception-interface": "^0.1",
+                "php": "^5.4 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "^0.1",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Exception\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Standards-compliant exception classes",
+            "time": "2017-09-05 08:24:01"
+        },
+        {
+            "name": "dhii/exception-helper-base",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/exception-helper-base.git",
+                "reference": "9275a60ef9940edaf2442e673ddf3035cdefbdeb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/exception-helper-base/zipball/9275a60ef9940edaf2442e673ddf3035cdefbdeb",
+                "reference": "9275a60ef9940edaf2442e673ddf3035cdefbdeb",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/exception": "dev-develop",
+                "php": "^5.4 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "^0.1",
+                "dhii/stringable-interface": "^0.1",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "suggest": {
+                "dhii/stringable-interface": "To be able to pass stringables instead of strings in some cases"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Exception\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Base functionality for exception helpers",
+            "time": "2017-09-05 07:47:07"
+        },
+        {
+            "name": "dhii/exception-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/exception-interface.git",
+                "reference": "fe64b30f67830474683357f77dc4a097bf84767e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/exception-interface/zipball/fe64b30f67830474683357f77dc4a097bf84767e",
+                "reference": "fe64b30f67830474683357f77dc4a097bf84767e",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/stringable-interface": "^0.1",
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Exception\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces for most common exceptions",
+            "time": "2017-09-01T18:00:26+00:00"
+        },
+        {
+            "name": "dhii/i18n-helper-base",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/i18n-helper-base.git",
+                "reference": "2738cd708429af2c05939c3acedf55e3ef83083d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/i18n-helper-base/zipball/2738cd708429af2c05939c3acedf55e3ef83083d",
+                "reference": "2738cd708429af2c05939c3acedf55e3ef83083d",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/i18n-interface": "^0.1",
+                "php": "^5.4 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\I18n\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "A base for internationalization consumers",
+            "time": "2017-08-24 07:54:03"
+        },
+        {
+            "name": "dhii/i18n-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/i18n-interface.git",
+                "reference": "2b8e842fdf1ba8888a3efecaea3b84691c5ee1e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/i18n-interface/zipball/2b8e842fdf1ba8888a3efecaea3b84691c5ee1e0",
+                "reference": "2b8e842fdf1ba8888a3efecaea3b84691c5ee1e0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/data-key-value-aware-interface": "^0.1",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "dhii/stringable-interface": "^0.1",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces for internationalization.",
+            "time": "2017-03-13T12:08:29+00:00"
+        },
+        {
+            "name": "dhii/machine-state-machine-interface",
+            "version": "dev-task/initial-interfaces",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/machine-state-machine-interface.git",
+                "reference": "a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/machine-state-machine-interface/zipball/a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801",
+                "reference": "a8800bbec7d191fb1bf0bde4ef6fa82fff7c2801",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/data-key-value-aware-interface": "^0.1",
+                "dhii/exception-interface": "^0.1",
+                "dhii/stringable-interface": "^0.1",
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\State\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces for state machines.",
+            "time": "2017-09-28 11:47:00"
+        },
+        {
+            "name": "dhii/psr-14",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/psr-14.git",
+                "reference": "ebfa94b69b34e34ffdfc7288aeea2f1a315288b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/psr-14/zipball/ebfa94b69b34e34ffdfc7288aeea2f1a315288b5",
+                "reference": "ebfa94b69b34e34ffdfc7288aeea2f1a315288b5",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventManager\\": "src/"
+                }
+            },
+            "authors": [
+                {
+                    "name": "Miguel Muscat",
+                    "email": "miguelmuscat93@gmail.com"
+                },
+                {
+                    "name": "Anton Ukhanev",
+                    "email": "xedin.unknown@gmail.com"
+                }
+            ],
+            "description": "A temporary PSR-14 repository.",
+            "support": {
+                "source": "https://github.com/Dhii/psr-14/tree/0.1",
+                "issues": "https://github.com/Dhii/psr-14/issues"
+            },
+            "time": "2016-07-06 18:43:19"
+        },
+        {
+            "name": "dhii/state-machine-abstract",
+            "version": "dev-task/initial-classes",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/state-machine-abstract.git",
+                "reference": "83b9929418958578c8ed091f8fc6a72571c59fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/state-machine-abstract/zipball/83b9929418958578c8ed091f8fc6a72571c59fa8",
+                "reference": "83b9929418958578c8ed091f8fc6a72571c59fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/machine-state-machine-interface": "dev-task/initial-interfaces",
+                "dhii/php-cs-fixer-config": "^0.1",
+                "dhii/stringable-interface": "^0.1",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\State\\": "src"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "csfix": [
+                    "php-cs-fixer fix -vvv"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Abstract functionality for state machines.",
+            "support": {
+                "source": "https://github.com/Dhii/state-machine-abstract/tree/task/initial-classes",
+                "issues": "https://github.com/Dhii/state-machine-abstract/issues"
+            },
+            "time": "2017-09-29 12:56:17"
+        },
+        {
+            "name": "dhii/stringable-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/stringable-interface.git",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/stringable-interface/zipball/b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Util\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interoperability interface for objects that can be cast to string",
+            "time": "2017-01-23T15:08:20+00:00"
+        },
+        {
+            "name": "dhii/transition-event-interface",
+            "version": "dev-task/initial-interfaces",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/transition-event-interface.git",
+                "reference": "4c9da633f3500bfe8350c7c662e103c398515de4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/transition-event-interface/zipball/4c9da633f3500bfe8350c7c662e103c398515de4",
+                "reference": "4c9da633f3500bfe8350c7c662e103c398515de4",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/machine-state-machine-interface": "dev-task/initial-interfaces",
+                "dhii/psr-14": "dev-master",
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "dhii/stringable-interface": "^0.1",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Events\\": "src"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "csfix": [
+                    "php-cs-fixer fix -vvv"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces for PSR-14 events related to state machine transitions.",
+            "support": {
+                "source": "https://github.com/Dhii/transition-event-interface/tree/task/initial-interfaces",
+                "issues": "https://github.com/Dhii/transition-event-interface/issues"
+            },
+            "time": "2017-09-29 16:17:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",
@@ -220,22 +718,22 @@
         },
         {
             "name": "guzzle/guzzle",
-            "version": "v3.8.1",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba"
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
-                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "php": ">=5.3.3",
-                "symfony/event-dispatcher": ">=2.1"
+                "symfony/event-dispatcher": "~2.1"
             },
             "replace": {
                 "guzzle/batch": "self.version",
@@ -262,18 +760,21 @@
                 "guzzle/stream": "self.version"
             },
             "require-dev": {
-                "doctrine/cache": "*",
-                "monolog/monolog": "1.*",
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
                 "phpunit/phpunit": "3.7.*",
-                "psr/log": "1.0.*",
-                "symfony/class-loader": "*",
-                "zendframework/zend-cache": "<2.3",
-                "zendframework/zend-log": "<2.3"
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.8-dev"
+                    "dev-master": "3.9-dev"
                 }
             },
             "autoload": {
@@ -297,7 +798,7 @@
                     "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -309,138 +810,41 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2014-01-28T22:29:15+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "phpunit/phpunit": "~4.0"
             },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
+                "psr-0": {
+                    "phpDocumentor": [
                         "src/"
                     ]
                 }
@@ -452,10 +856,10 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1408,30 +1812,24 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f9f19a39ee178f61bb2190f51ff7c517c2159315"
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f9f19a39ee178f61bb2190f51ff7c517c2159315",
-                "reference": "f9f19a39ee178f61bb2190f51ff7c517c2159315",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0b8541d18507d10204a08384640ff6df3c739ebe",
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/filesystem": "~2.8|~3.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3",
-                "symfony/finder": "<3.3"
+                "php": ">=5.3.9",
+                "symfony/filesystem": "~2.3|~3.0.0"
             },
             "require-dev": {
-                "symfony/dependency-injection": "~3.3",
-                "symfony/finder": "~3.3",
-                "symfony/yaml": "~3.0"
+                "symfony/yaml": "~2.7|~3.0.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1439,7 +1837,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1466,48 +1864,41 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-04T16:28:07+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf"
+                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
-                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c0807a2ca978e64d8945d373a9221a5c35d1a253",
+                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0",
+                "php": ">=5.3.9",
+                "symfony/debug": "^2.7.2|~3.0.0",
                 "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1534,36 +1925,37 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-06T16:40:18+00:00"
+            "time": "2017-08-27T14:29:03+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "8beb24eec70b345c313640962df933499373a944"
+                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/8beb24eec70b345c313640962df933499373a944",
-                "reference": "8beb24eec70b345c313640962df933499373a944",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/efc9656dcb227e1459905d5aa51e43dfec76e752",
+                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=5.3.9",
                 "psr/log": "~1.0"
             },
             "conflict": {
                 "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "symfony/class-loader": "~2.2|~3.0.0",
+                "symfony/http-kernel": "~2.3.24|~2.5.9|^2.6.2|~3.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1590,34 +1982,31 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-01T13:23:39+00:00"
+            "time": "2017-08-27T14:29:03+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485"
+                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/54ca9520a00386f83bca145819ad3b619aaa2485",
-                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1377400fd641d7d1935981546aaef780ecd5bf6d",
+                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/stopwatch": "~2.8|~3.0"
+                "symfony/config": "^2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -1626,7 +2015,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1653,29 +2042,29 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
+            "time": "2017-06-02T07:47:27+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb"
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
-                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/714b1036010c354ae2b25d7f9ca27e14e265e9f2",
+                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1702,29 +2091,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
+            "time": "2017-07-11T07:12:11+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e"
+                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
-                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
+                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1751,7 +2140,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
+            "time": "2017-06-01T20:52:29+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1814,25 +2203,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0"
+                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
-                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
+                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1859,29 +2248,29 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
+            "time": "2017-07-03T08:04:30+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "9a5610a8d6a50985a7be485c0ba745c22607beeb"
+                "reference": "e02577b841394a78306d7b547701bb7bb705bad5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9a5610a8d6a50985a7be485c0ba745c22607beeb",
-                "reference": "9a5610a8d6a50985a7be485c0ba745c22607beeb",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e02577b841394a78306d7b547701bb7bb705bad5",
+                "reference": "e02577b841394a78306d7b547701bb7bb705bad5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1908,35 +2297,29 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.9",
+            "version": "v2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
-                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1963,62 +2346,19 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29T21:54:42+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2017-06-01T20:52:29+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "dhii/machine-state-machine-interface": 20,
+        "dhii/state-machine-abstract": 20,
+        "dhii/i18n-helper-base": 20,
+        "dhii/exception-helper-base": 20,
+        "dhii/transition-event-interface": 20,
+        "dhii/psr-14": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1812,16 +1812,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe"
+                "reference": "1dbeaa8e2db4b29159265867efff075ad961558c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0b8541d18507d10204a08384640ff6df3c739ebe",
-                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe",
+                "url": "https://api.github.com/repos/symfony/config/zipball/1dbeaa8e2db4b29159265867efff075ad961558c",
+                "reference": "1dbeaa8e2db4b29159265867efff075ad961558c",
                 "shasum": ""
             },
             "require": {
@@ -1864,20 +1864,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:07:15+00:00"
+            "time": "2017-10-04T18:56:36+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253"
+                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c0807a2ca978e64d8945d373a9221a5c35d1a253",
-                "reference": "c0807a2ca978e64d8945d373a9221a5c35d1a253",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
+                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
                 "shasum": ""
             },
             "require": {
@@ -1925,20 +1925,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27T14:29:03+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752"
+                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/efc9656dcb227e1459905d5aa51e43dfec76e752",
-                "reference": "efc9656dcb227e1459905d5aa51e43dfec76e752",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/eaaec993ca5e8067e204b2ee653cdd142961f33e",
+                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e",
                 "shasum": ""
             },
             "require": {
@@ -1982,20 +1982,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-27T14:29:03+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d"
+                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1377400fd641d7d1935981546aaef780ecd5bf6d",
-                "reference": "1377400fd641d7d1935981546aaef780ecd5bf6d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7fe089232554357efb8d4af65ce209fc6e5a2186",
+                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186",
                 "shasum": ""
             },
             "require": {
@@ -2042,20 +2042,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T07:47:27+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2"
+                "reference": "5e3af878f144089faddd4060a48cadae4fc44dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/714b1036010c354ae2b25d7f9ca27e14e265e9f2",
-                "reference": "714b1036010c354ae2b25d7f9ca27e14e265e9f2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5e3af878f144089faddd4060a48cadae4fc44dee",
+                "reference": "5e3af878f144089faddd4060a48cadae4fc44dee",
                 "shasum": ""
             },
             "require": {
@@ -2091,20 +2091,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-11T07:12:11+00:00"
+            "time": "2017-10-02T08:46:46+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad"
+                "reference": "a945724b201f74d543e356f6059c930bb8d10c92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
-                "reference": "4f4e84811004e065a3bb5ceeb1d9aa592630f9ad",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a945724b201f74d543e356f6059c930bb8d10c92",
+                "reference": "a945724b201f74d543e356f6059c930bb8d10c92",
                 "shasum": ""
             },
             "require": {
@@ -2140,7 +2140,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T20:52:29+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2203,16 +2203,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8"
+                "reference": "26c9fb02bf06bd6b90f661a5bd17e510810d0176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
-                "reference": "57e52a0a6a80ea0aec4fc1b785a7920a95cb88a8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/26c9fb02bf06bd6b90f661a5bd17e510810d0176",
+                "reference": "26c9fb02bf06bd6b90f661a5bd17e510810d0176",
                 "shasum": ""
             },
             "require": {
@@ -2248,20 +2248,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-03T08:04:30+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "e02577b841394a78306d7b547701bb7bb705bad5"
+                "reference": "28ee62ea4736431ca817cdaebcb005663e9cd1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e02577b841394a78306d7b547701bb7bb705bad5",
-                "reference": "e02577b841394a78306d7b547701bb7bb705bad5",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/28ee62ea4736431ca817cdaebcb005663e9cd1cb",
+                "reference": "28ee62ea4736431ca817cdaebcb005663e9cd1cb",
                 "shasum": ""
             },
             "require": {
@@ -2297,20 +2297,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:07:15+00:00"
+            "time": "2017-10-01T21:00:16+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.27",
+            "version": "v2.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5"
+                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
-                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/842fb6df22180244b4c65935ce1a88d324e5ff9e",
+                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e",
                 "shasum": ""
             },
             "require": {
@@ -2346,7 +2346,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T20:52:29+00:00"
+            "time": "2017-10-05T14:38:30+00:00"
         }
     ],
     "aliases": [],

--- a/src/AbstractEventStateMachine.php
+++ b/src/AbstractEventStateMachine.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace RebelCode\State;
+
+use Dhii\Events\TransitionEventInterface;
+use Dhii\Util\String\StringableInterface as Stringable;
+use Exception;
+use Psr\EventManager\EventManagerInterface;
+
+abstract class AbstractEventStateMachine
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _transition($transition)
+    {
+        $event = $this->_getTransitionEvent($transition);
+
+        try {
+            $this->_getEventManager()->trigger($event);
+        } catch (Exception $ex) {
+            $exception = $this->_createCouldNotTransitionException(
+                $this->__('The triggered event threw an exception'),
+                null,
+                $ex,
+                $transition
+            );
+        }
+
+        if (!$event->isTransitionAborted()) {
+            $this->_setState($this->_getNewState($event));
+        }
+
+        if (isset($exception) && $exception instanceof Exception) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Retrieves the event manager associated with this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @return EventManagerInterface The event manager instance.
+     */
+    abstract protected function _getEventManager();
+
+    /**
+     * Retrieves the transition event instance for a transition.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $transition The transition related to the transition event.
+     *
+     * @return TransitionEventInterface The transition event instance.
+     */
+    abstract protected function _getTransitionEvent($transition);
+
+    /**
+     * Retrieves the new state for a given event transition.
+     *
+     * @since [*next-version*]
+     *
+     * @param TransitionEventInterface $event The event.
+     *
+     * @return string|Stringable The new state.
+     */
+    abstract protected function _getNewState(TransitionEventInterface $event);
+
+    /**
+     * Sets the state for this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable|null $state The state, or null.
+     */
+    abstract protected function _setState($state);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    abstract protected function _createCouldNotTransitionException(
+        $message = null,
+        $code = null,
+        Exception $previous = null,
+        $transition = null
+    );
+
+    /**
+     * Translates a string, and replaces placeholders.
+     *
+     * @since [*next-version*]
+     * @see   sprintf()
+     * @see   _translate()
+     *
+     * @param string $string  The format string to translate.
+     * @param array  $args    Placeholder values to replace in the string.
+     * @param mixed  $context The context for translation.
+     *
+     * @return string The translated string.
+     */
+    abstract protected function __($string, $args = [], $context = null);
+}

--- a/src/AbstractEventStateMachine.php
+++ b/src/AbstractEventStateMachine.php
@@ -84,6 +84,23 @@ abstract class AbstractEventStateMachine
     abstract protected function _setState($state);
 
     /**
+     * Creates an state machine related exception.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable|null $message  The error message, if any.
+     * @param int|null               $code     The error code, if any.
+     * @param Exception|null         $previous The previous exception for chaining, if any.
+     *
+     * @return CouldNotTransitionExceptionInterface The created exception.
+     */
+    abstract protected function _createStateMachineException(
+        $message = null,
+        $code = null,
+        Exception $previous = null
+    );
+
+    /**
      * Creates an exception for transition failure.
      *
      * @since [*next-version*]

--- a/src/AbstractEventStateMachine.php
+++ b/src/AbstractEventStateMachine.php
@@ -7,6 +7,11 @@ use Dhii\Util\String\StringableInterface as Stringable;
 use Exception;
 use Psr\EventManager\EventManagerInterface;
 
+/**
+ * Abstract functionality for event-based state machines.
+ *
+ * @since [*next-version*]
+ */
 abstract class AbstractEventStateMachine
 {
     /**
@@ -79,9 +84,16 @@ abstract class AbstractEventStateMachine
     abstract protected function _setState($state);
 
     /**
-     * {@inheritdoc}
+     * Creates an exception for transition failure.
      *
      * @since [*next-version*]
+     *
+     * @param string|Stringable|null $message    The error message, if any.
+     * @param int|null               $code       The error code, if any.
+     * @param Exception|null         $previous   The previous exception for chaining, if any.
+     * @param string|Stringable|null $transition The transition that failed, if any.
+     *
+     * @return CouldNotTransitionExceptionInterface The created exception.
      */
     abstract protected function _createCouldNotTransitionException(
         $message = null,

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -16,8 +16,7 @@ use RebelCode\State\Exception\CouldNotTransitionException;
  * A readable, event-driven state machine.
  *
  * This implementation does not use an internal state graph. Instead, transition given to be applied will be
- * used as the new state. As such, it is perfectly valid to transition to the same state, thus making this state
- * machine implementation non-deterministic.
+ * used as the new state. As such, it is perfectly valid to transition to the same state.
  *
  * An event manager is used to trigger events when a transition is being applied. The handlers attached to the manager
  * can abort the transition via {@link `TransitionEventInterface::abortTransition()`}.

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -13,10 +13,23 @@ use Psr\EventManager\EventManagerInterface;
 use RebelCode\State\Exception\CouldNotTransitionException;
 
 /**
- * A readable event driven state machine.
+ * A readable, event-driven state machine.
  *
- * The machine triggers events on transition and determines the new state depending on the event.
- * Event handlers can set the new state through the event and can also abort the transition altogether.
+ * This implementation does not use an internal state graph. Instead, transition given to be applied will be
+ * used as the new state. As such, it is perfectly valid to transition to the same state, thus making this state
+ * machine implementation non-deterministic.
+ *
+ * An event manager is used to trigger events when a transition is being applied. The handlers attached to the manager
+ * can abort the transition via {@link `TransitionEventInterface::abortTransition()`}.
+ *
+ * Unless the transition is explicitly aborted by handlers, it will be applied after execution of all handlers even if
+ * an exception is thrown. If this is not desirable behaviour, handlers can catch exceptions and abort the transition
+ * in their `catch` body.
+ *
+ * It is important to note that handlers should not rely on {@link `TransitionEventInterface::abortTransition()`} to
+ * guarantee abortion. Handlers that are invoked at a later time may explicitly call `$event->abortTransition(false)`.
+ * To guarantee that a transition has been aborted, handlers must also stop propagation via
+ * {@link `Psr\EventManager\EventInterface::stopPropagation()`}.
  *
  * @since [*next-version*]
  */

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -5,12 +5,14 @@ namespace RebelCode\State;
 use Dhii\Events\TransitionEventInterface;
 use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
 use Dhii\I18n\StringTranslatingTrait;
+use Dhii\State\Exception\CouldNotTransitionExceptionInterface;
 use Dhii\State\ReadableStateMachineInterface;
 use Dhii\State\StateAwareTrait;
 use Dhii\Util\String\StringableInterface as Stringable;
 use Exception;
 use Psr\EventManager\EventManagerInterface;
 use RebelCode\State\Exception\CouldNotTransitionException;
+use RebelCode\State\Exception\StateMachineException;
 
 /**
  * A readable, event-driven state machine.
@@ -333,6 +335,19 @@ class EventStateMachine extends AbstractEventStateMachine implements ReadableSta
     protected function _createTransitionEvent($name, $transition, $target = null, array $params = [])
     {
         return new TransitionEvent((string) $name, $transition, $target, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _createStateMachineException(
+        $message = null,
+        $code = null,
+        Exception $previous = null
+    ) {
+        return new StateMachineException($message, $code, $previous, $this);
     }
 
     /**

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -11,7 +11,6 @@ use Dhii\Util\String\StringableInterface as Stringable;
 use Exception;
 use Psr\EventManager\EventManagerInterface;
 use RebelCode\State\Exception\CouldNotTransitionException;
-use RebelCode\State\Exception\StateMachineException;
 
 /**
  * A readable event driven state machine.

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -34,7 +34,7 @@ class EventStateMachine extends AbstractEventStateMachine implements ReadableSta
      *
      * @since [*next-version*]
      */
-    const DEFAULT_EVENT_NAME_FORMAT = 'on_%s_transition';
+    const DEFAULT_EVENT_NAME_FORMAT = 'on_transition';
 
     /*
      * Provides string translating functionality.

--- a/src/EventStateMachine.php
+++ b/src/EventStateMachine.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace RebelCode\State;
+
+use Dhii\Events\TransitionEventInterface;
+use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
+use Dhii\I18n\StringTranslatingTrait;
+use Dhii\State\ReadableStateMachineInterface;
+use Dhii\State\StateAwareTrait;
+use Dhii\Util\String\StringableInterface as Stringable;
+use Exception;
+use Psr\EventManager\EventManagerInterface;
+use RebelCode\State\Exception\CouldNotTransitionException;
+use RebelCode\State\Exception\StateMachineException;
+
+/**
+ * A readable event driven state machine.
+ *
+ * The machine triggers events on transition and determines the new state depending on the event.
+ * Event handlers can set the new state through the event and can also abort the transition altogether.
+ *
+ * @since [*next-version*]
+ */
+class EventStateMachine implements ReadableStateMachineInterface
+{
+    /**
+     * The key for the current state in event params.
+     *
+     * @since [*next-version*]
+     */
+    const K_PARAM_CURRENT_STATE = 'current_state';
+
+    /**
+     * The key for the new state in event params.
+     *
+     * @since [*next-version*]
+     */
+    const K_PARAM_NEW_STATE = 'new_state';
+
+    /**
+     * The default sprintf-style format for event names.
+     *
+     * @since [*next-version*]
+     */
+    const DEFAULT_EVENT_NAME_FORMAT = 'on_%s_transition';
+
+    /*
+     * Provides string translating functionality.
+     *
+     * @since [*next-version*]
+     */
+    use StringTranslatingTrait;
+
+    /*
+     * Provides functionality for creating invalid argument exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateInvalidArgumentExceptionCapableTrait;
+
+    /*
+     * Provides awareness of a state.
+     *
+     * @since [*next-version*]
+     */
+    use StateAwareTrait;
+
+    /**
+     * The event manager instance.
+     *
+     * @since [*next-version*]
+     *
+     * @var EventManagerInterface
+     */
+    protected $eventManager;
+
+    /**
+     * The event target, for context.
+     *
+     * @since [*next-version*]
+     *
+     * @var mixed
+     */
+    protected $target;
+
+    /**
+     * The format for event names.
+     *
+     * @since [*next-version*]
+     *
+     * @var string|Stringable
+     */
+    protected $eventNameFormat;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param EventManagerInterface $eventManager    The event manager.
+     * @param string|Stringable     $state           The initial state.
+     * @param string|null           $eventNameFormat The format for event names.
+     * @param mixed|null            $target          The target for triggered events, used for context.
+     */
+    public function __construct(
+        EventManagerInterface $eventManager,
+        $state,
+        $eventNameFormat = null,
+        $target = null
+    ) {
+        $this->_setEventManager($eventManager);
+        $this->_setState($state);
+        $this->_setEventNameFormat($eventNameFormat);
+        $this->_setTarget($target);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function getState()
+    {
+        return $this->_getState();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function canTransition($transition)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function transition($transition)
+    {
+        $event = $this->_getTransitionEvent($transition);
+
+        try {
+            $this->_getEventManager()->trigger($event);
+        } catch (Exception $exception) {
+            throw $this->_createCouldNotTransitionException(
+                $this->__('The triggered event threw an exception'),
+                null,
+                $exception,
+                $transition
+            );
+        }
+
+        try {
+            $newState = $event->getParam(static::K_PARAM_NEW_STATE);
+
+            if (!$event->isTransitionAborted()) {
+                $this->_setState($newState);
+            }
+        } catch (Exception $exception) {
+            throw $this->_createCouldNotTransitionException(
+                $this->__('Failed to update state'),
+                null,
+                $exception,
+                $transition
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks if the subject is a valid string or stringable object.
+     *
+     * @since [*next-version*]
+     *
+     * @param mixed $subject The subject.
+     *
+     * @return bool True if the subject is a string or stringable object, false if not.
+     */
+    protected function _isValidString($subject)
+    {
+        return is_string($subject) || $subject instanceof Stringable;
+    }
+
+    /**
+     * Retrieves the event manager associated with this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @return EventManagerInterface The event manager instance.
+     */
+    protected function _getEventManager()
+    {
+        return $this->eventManager;
+    }
+
+    /**
+     * Sets the event manager for this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @param EventManagerInterface $eventManager The event manager instance.
+     *
+     * @return $this
+     */
+    protected function _setEventManager($eventManager)
+    {
+        $this->eventManager = $eventManager;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the event target.
+     *
+     * @since [*next-version*]
+     *
+     * @return mixed
+     */
+    protected function _getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * Sets the event target.
+     *
+     * @since [*next-version*]
+     *
+     * @param mixed $target The event target.
+     *
+     * @return $this
+     */
+    protected function _setTarget($target)
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the event name format.
+     *
+     * @since [*next-version*]
+     *
+     * @return string|Stringable The sprintf-style format for event names.
+     */
+    protected function _getEventNameFormat()
+    {
+        return $this->eventNameFormat === null
+            ? static::DEFAULT_EVENT_NAME_FORMAT
+            : $this->eventNameFormat;
+    }
+
+    /**
+     * Sets the event name format.
+     *
+     * @since [*next-version*]
+     *
+     * @param Stringable|string $eventNameFormat The sprintf-style format for event names.
+     *
+     * @return $this
+     */
+    protected function _setEventNameFormat($eventNameFormat)
+    {
+        if ($eventNameFormat !== null && !$this->_isValidString($eventNameFormat)) {
+            throw $this->_createInvalidArgumentException(
+                $this->__('Argument is not a string or stringable object'),
+                null,
+                null,
+                $eventNameFormat
+            );
+        }
+
+        $this->eventNameFormat = $eventNameFormat;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the transition event instance for a transition.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $transition The transition related to the transition event.
+     *
+     * @return TransitionEventInterface The transition event instance.
+     */
+    protected function _getTransitionEvent($transition)
+    {
+        return $this->_createTransitionEvent(
+            $this->_generateEventName($transition),
+            $transition,
+            $this->_getTarget(),
+            $this->_getEventParams($transition)
+        );
+    }
+
+    /**
+     * Generates an event name for a transition event.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $transition The transition related to the transition event.
+     *
+     * @return string The event name.
+     */
+    protected function _generateEventName($transition)
+    {
+        return sprintf((string) $this->_getEventNameFormat(), $transition);
+    }
+
+    /**
+     * Retrieves the event params for a transition event.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $transition The transition related to the transition event.
+     *
+     * @return array The event params.
+     */
+    protected function _getEventParams($transition)
+    {
+        return [
+            static::K_PARAM_CURRENT_STATE => $this->_getState(),
+            static::K_PARAM_NEW_STATE     => null,
+        ];
+    }
+
+    /**
+     * Creates a transition event.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $name       The event name.
+     * @param string|Stringable $transition The transition.
+     * @param mixed|null        $target     The target, used for context.
+     * @param array             $params     The event params.
+     *
+     * @return TransitionEvent The created instance.
+     */
+    protected function _createTransitionEvent($name, $transition, $target = null, array $params = [])
+    {
+        return new TransitionEvent((string) $name, $transition, $target, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _createStateMachineException($message = null, $code = null, Exception $previous = null)
+    {
+        return new StateMachineException($message, $code, $previous, $this);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _createCouldNotTransitionException(
+        $message = null,
+        $code = null,
+        Exception $previous = null,
+        $transition = null
+    ) {
+        return new CouldNotTransitionException($message, $code, $previous, $this, $transition);
+    }
+}

--- a/src/Exception/AbstractBaseStateMachineException.php
+++ b/src/Exception/AbstractBaseStateMachineException.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace RebelCode\State\Exception;
+
+use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
+use Dhii\I18n\StringTranslatingTrait;
+use Dhii\State\Exception\StateMachineExceptionInterface;
+use Dhii\State\StateMachineAwareTrait;
+use Exception;
+
+/**
+ * Base common functionality for exceptions thrown in relation to a state machine.
+ *
+ * @since [*next-version*]
+ */
+class AbstractBaseStateMachineException extends Exception implements StateMachineExceptionInterface
+{
+    /*
+     * Provides string translating functionality.
+     *
+     * @since [*next-version*]
+     */
+    use StringTranslatingTrait;
+
+    /*
+     * Provides awareness of a state machine.
+     *
+     * @since [*next-version*]
+     */
+    use StateMachineAwareTrait {
+        _getStateMachine as public getStateMachine;
+    }
+
+    /*
+     * Provides functionality for creating invalid argument exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateInvalidArgumentExceptionCapableTrait;
+}

--- a/src/Exception/CouldNotTransitionException.php
+++ b/src/Exception/CouldNotTransitionException.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace RebelCode\State\Exception;
+
+use Dhii\State\Exception\CouldNotTransitionExceptionInterface;
+use Dhii\State\StateMachineInterface;
+use Dhii\State\TransitionAwareTrait;
+use Dhii\Util\String\StringableInterface as Stringable;
+use Exception;
+
+/**
+ * An exception thrown when a transition failed.
+ *
+ * @since [*next-version*]
+ */
+class CouldNotTransitionException
+    extends AbstractBaseStateMachineException
+    implements CouldNotTransitionExceptionInterface
+{
+    /*
+     * Provides awareness of a transition.
+     *
+     * @since [*next-version*]
+     */
+    use TransitionAwareTrait {
+        _getTransition as public getTransition;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param string                     $message      The error message.
+     * @param int                        $code         The error code.
+     * @param Exception|null             $previous     The previous exception, for chaining.
+     * @param StateMachineInterface|null $stateMachine The state machine that erred.
+     * @param string|Stringable|null     $transition   The transition that failed.
+     */
+    public function __construct(
+        $message = '',
+        $code = 0,
+        Exception $previous = null,
+        StateMachineInterface $stateMachine = null,
+        $transition = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        $this->_setStateMachine($stateMachine);
+        $this->_setTransition($transition);
+    }
+}

--- a/src/Exception/StateMachineException.php
+++ b/src/Exception/StateMachineException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace RebelCode\State\Exception;
+
+use Dhii\State\StateMachineInterface;
+use Exception;
+
+/**
+ * A generic exception thrown in relation to a state machine.
+ *
+ * @since [*next-version*]
+ */
+class StateMachineException extends AbstractBaseStateMachineException
+{
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param string                     $message      The error message.
+     * @param int                        $code         The error code.
+     * @param Exception|null             $previous     The previous exception, for chaining.
+     * @param StateMachineInterface|null $stateMachine The state machine that erred.
+     */
+    public function __construct(
+        $message = '',
+        $code = 0,
+        Exception $previous = null,
+        StateMachineInterface $stateMachine = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        $this->_setStateMachine($stateMachine);
+    }
+}

--- a/src/TransitionEvent.php
+++ b/src/TransitionEvent.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace RebelCode\State;
+
+use Dhii\Events\TransitionEventInterface;
+use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
+use Dhii\I18n\StringTranslatingTrait;
+use Dhii\State\ReadableStateMachineInterface;
+use Dhii\State\TransitionAwareTrait;
+use Dhii\Util\String\StringableInterface as Stringable;
+
+/**
+ * An event triggered in relation to a transition.
+ *
+ * @since [*next-version*]
+ */
+class TransitionEvent implements TransitionEventInterface
+{
+    /*
+     * Provides string translating functionality.
+     *
+     * @since [*next-version*]
+     */
+    use StringTranslatingTrait;
+
+    /*
+     * Provides functionality for creating invalid argument exceptions.
+     *
+     * @since [*next-version*]
+     */
+    use CreateInvalidArgumentExceptionCapableTrait;
+
+    /*
+     *
+     * Provides awareness of a transition.
+     *
+     * @since [*next-version*]
+     */
+    use TransitionAwareTrait {
+        _getTransition as public getTransition;
+    }
+
+    /**
+     * The event name.
+     *
+     * @since [*next-version*]
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The parameters.
+     *
+     * @since [*next-version*]
+     *
+     * @var array
+     */
+    protected $params;
+
+    /**
+     * The target context object.
+     *
+     * @since [*next-version*]
+     *
+     * @var mixed
+     */
+    protected $target;
+
+    /**
+     * The stopped propagation flag.
+     *
+     * @since [*next-version*]
+     *
+     * @var bool
+     */
+    protected $isPropagationStopped;
+
+    /**
+     * The aborted transition flag.
+     *
+     * @since [*next-version*]
+     *
+     * @var bool
+     */
+    protected $isTransitionAborted;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param string            $name       The event name.
+     * @param string|Stringable $transition The transition.
+     * @param mixed             $target     The target, for context.
+     * @param array             $params     The event parameters.
+     */
+    public function __construct(
+        $name,
+        $transition,
+        $target = null,
+        array $params = []
+    ) {
+        $this->setName($name);
+        $this->stopPropagation(false);
+        $this->setParams($params);
+        $this->setTarget($target);
+        $this->_setTransition($transition);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function getParam($name)
+    {
+        return isset($this->params[$name])
+            ? $this->params[$name]
+            : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function setParams(array $params)
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     *
+     * @return ReadableStateMachineInterface
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function setTarget($target)
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function isPropagationStopped()
+    {
+        return $this->isPropagationStopped;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function stopPropagation($flag)
+    {
+        $this->isPropagationStopped = $flag;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function isTransitionAborted()
+    {
+        return $this->isTransitionAborted;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function abortTransition($abort)
+    {
+        $this->isTransitionAborted = $abort;
+
+        return $this;
+    }
+}

--- a/test/unit/AbstractEventStateMachineTest.php
+++ b/test/unit/AbstractEventStateMachineTest.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace RebelCode\State\UnitTest;
+
+use Dhii\Events\TransitionEventInterface;
+use Dhii\Util\String\StringableInterface;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see RebelCode\State\AbstractEventStateMachine}.
+ *
+ * @since [*next-version*]
+ */
+class AbstractEventStateMachineTest extends TestCase
+{
+    /**
+     * The class name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\State\AbstractEventStateMachine';
+
+    /**
+     * The FQN of the event manager interface.
+     *
+     * @since [*next-version*]
+     */
+    const EVENT_MANAGER_INTERFACE = 'Psr\EventManager\EventManagerInterface';
+
+    /**
+     * The FQN of the transition event interface.
+     *
+     * @since [*next-version*]
+     */
+    const TRANSITION_EVENT_INTERFACE = 'Dhii\Events\TransitionEventInterface';
+
+    /**
+     * The FQN of the readable state machine interface.
+     *
+     * @since [*next-version*]
+     */
+    const READABLE_STATE_MACHINE_INTERFACE = 'Dhii\State\ReadableStateMachineInterface';
+
+    /**
+     * The FQN of the stringable interface.
+     *
+     * @since [*next-version*]
+     */
+    const STRINGABLE_INTERFACE = 'Dhii\Util\String\StringableInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $methods The methods to mock.
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createInstance(array $methods = [])
+    {
+        $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor();
+
+        if (!empty($methods)) {
+            $mock->setMethods($methods);
+        }
+
+        return $mock->getMockForAbstractClass();
+    }
+
+    /**
+     * Creates an event manager mock instance for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createEventManager()
+    {
+        $mock = $this->getMockBuilder(static::EVENT_MANAGER_INTERFACE)
+                     ->setMethods(
+                         [
+                             'attach',
+                             'detach',
+                             'trigger',
+                             'clearListeners',
+                         ]
+                     );
+
+        return $mock->getMock();
+    }
+
+    /**
+     * Creates a transition event instance for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @param string     $name    The event name.
+     * @param array      $params  The event params.
+     * @param mixed|null $target  The event target, for context.
+     * @param bool       $aborted The aborted flag.
+     *
+     * @return TransitionEventInterface The created transition event instance.
+     */
+    public function createTransitionEvent($name = '', $params = [], $target = null, $aborted = false)
+    {
+        return $this->mock(static::TRANSITION_EVENT_INTERFACE)
+                    ->getName($name)
+                    ->setName()
+                    ->getParams($params)
+                    ->setParams()
+                    ->getParam(
+                        function($key) use ($params) {
+                            return array_key_exists($key, $params)
+                                ? $params[$key]
+                                : null;
+                        }
+                    )
+                    ->getTarget($target)
+                    ->setTarget()
+                    ->getTransition()
+                    ->stopPropagation()
+                    ->isPropagationStopped()
+                    ->abortTransition()
+                    ->isTransitionAborted($aborted)
+                    ->new();
+    }
+
+    /**
+     * Creates a mock stringable instance for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $string The string to return when the object is casted to string.
+     *
+     * @return StringableInterface
+     */
+    public function createStringable($string)
+    {
+        return $this->mock(static::STRINGABLE_INTERFACE)
+                    ->__toString($string)
+                    ->new();
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME,
+            $subject,
+            'A valid instance of the test subject could not be created.'
+        );
+    }
+
+    /**
+     * Tests the transition method to ensure that the abstracted algorithm works as expected.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransition()
+    {
+        $subject    = $this->createInstance();
+        $reflect    = $this->reflect($subject);
+        $transition = uniqid('transition-');
+
+        // Expect subject will determine event via _getTransitionEvent(), mock result
+        $event = $this->createTransitionEvent($transition, [], null, false);
+        $subject->expects($this->once())
+                ->method('_getTransitionEvent')
+                ->with($transition)
+                ->willReturn($event);
+
+        // Expect subject to retrieve the event manager, mock result
+        $evtManager = $this->createEventManager();
+        $subject->expects($this->once())
+                ->method('_getEventManager')
+                ->willReturn($evtManager);
+
+        // Expect subject to determine new state via _getNewState(), mock result
+        $newState = uniqid('new-state-');
+        $subject->expects($this->once())
+                ->method('_getNewState')
+                ->with($event)
+                ->willReturn($newState);
+
+        // Expect subject to set the state using the mocked result for _getNewState()
+        $subject->expects($this->once())
+                ->method('_setState')
+                ->with($newState);
+
+        // Expect subject to invoke event manager's trigger method.
+        $evtManager->expects($this->once())
+                   ->method('trigger')
+                   ->with($event);
+
+        $reflect->_transition($transition);
+    }
+
+    /**
+     * Tests the transition method with an aborted transition to ensure that the new state is not set.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionAborted()
+    {
+        $subject    = $this->createInstance();
+        $reflect    = $this->reflect($subject);
+        $transition = uniqid('transition-');
+
+        // Expect subject will determine event via _getTransitionEvent(), mock result
+        $event = $this->createTransitionEvent($transition, [], null, true);
+        $subject->expects($this->once())
+                ->method('_getTransitionEvent')
+                ->with($transition)
+                ->willReturn($event);
+
+        // Expect subject to retrieve the event manager, mock result
+        $evtManager = $this->createEventManager();
+        $subject->expects($this->once())
+                ->method('_getEventManager')
+                ->willReturn($evtManager);
+
+        // Expect subject to NOT determine new state via _getNewState(), mock result
+        $newState = uniqid('new-state-');
+        $subject->expects($this->never())
+                ->method('_getNewState')
+                ->with($this->anything())
+                ->willReturn($newState);
+
+        // Expect subject to NOT set the state using the mocked result for _getNewState()
+        $subject->expects($this->never())
+                ->method('_setState')
+                ->with($newState);
+
+        // Expect subject to invoke event manager's trigger method.
+        $evtManager->expects($this->once())
+                   ->method('trigger')
+                   ->with($event);
+
+        $reflect->_transition($transition);
+    }
+
+    /**
+     * Tests the transition method when an exception is thrown by an event handler to ensure that the state
+     * is still updated.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionException()
+    {
+        $subject    = $this->createInstance();
+        $reflect    = $this->reflect($subject);
+        $transition = uniqid('transition-');
+
+        // Expect subject will determine event via _getTransitionEvent(), mock result
+        $event = $this->createTransitionEvent($transition, [], null, false);
+        $subject->expects($this->once())
+                ->method('_getTransitionEvent')
+                ->with($transition)
+                ->willReturn($event);
+
+        // Expect subject to retrieve the event manager, mock result
+        $evtManager = $this->createEventManager();
+        $subject->expects($this->once())
+                ->method('_getEventManager')
+                ->willReturn($evtManager);
+
+        // Expect subject to determine new state via _getNewState(), mock result
+        $newState = uniqid('new-state-');
+        $subject->expects($this->once())
+                ->method('_getNewState')
+                ->with($this->anything())
+                ->willReturn($newState);
+
+        // Expect subject to set the state using the mocked result for _getNewState()
+        $subject->expects($this->once())
+                ->method('_setState')
+                ->with($newState);
+
+        // Expect subject to call the exception factory, mock result
+        $subject->expects($this->once())
+                ->method('_createCouldNotTransitionException')
+                ->willReturn(new Exception());
+
+        // Expect subject to invoke event manager's trigger method, which will throw an exception
+        $evtManager->expects($this->once())
+                   ->method('trigger')
+                   ->willThrowException(new Exception());
+
+        $this->setExpectedException('Exception');
+
+        $reflect->_transition($transition);
+    }
+
+    /**
+     * Tests the transition method with an aborted transition and a thrown exception to ensure that the
+     * new state is not set.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionExceptionAborted()
+    {
+        $subject    = $this->createInstance();
+        $reflect    = $this->reflect($subject);
+        $transition = uniqid('transition-');
+
+        // Expect subject will determine event via _getTransitionEvent(), mock result
+        $event = $this->createTransitionEvent($transition, [], null, true);
+        $subject->expects($this->once())
+                ->method('_getTransitionEvent')
+                ->with($transition)
+                ->willReturn($event);
+
+        // Expect subject to retrieve the event manager, mock result
+        $evtManager = $this->createEventManager();
+        $subject->expects($this->once())
+                ->method('_getEventManager')
+                ->willReturn($evtManager);
+
+        // Expect subject to NOT determine new state via _getNewState(), mock result
+        $newState = uniqid('new-state-');
+        $subject->expects($this->never())
+                ->method('_getNewState')
+                ->with($this->anything())
+                ->willReturn($newState);
+
+        // Expect subject to NOT set the state using the mocked result for _getNewState()
+        $subject->expects($this->never())
+                ->method('_setState')
+                ->with($newState);
+
+        // Expect subject to call the exception factory, mock result
+        $subject->expects($this->once())
+                ->method('_createCouldNotTransitionException')
+                ->willReturn(new Exception());
+
+        // Expect subject to invoke event manager's trigger method, which will throw an exception
+        $evtManager->expects($this->once())
+                   ->method('trigger')
+                   ->willThrowException(new Exception());
+
+        $this->setExpectedException('Exception');
+
+        $reflect->_transition($transition);
+    }
+}

--- a/test/unit/AbstractEventStateMachineTest.php
+++ b/test/unit/AbstractEventStateMachineTest.php
@@ -246,6 +246,13 @@ class AbstractEventStateMachineTest extends TestCase
                    ->method('trigger')
                    ->with($event);
 
+        $subject->expects($this->once())
+            ->method('_createCouldNotTransitionException')
+            ->with($this->anything(), $this->anything(), $this->anything(), $transition)
+            ->willReturn(new Exception());
+
+        $this->setExpectedException('Exception');
+
         $reflect->_transition($transition);
     }
 
@@ -288,7 +295,7 @@ class AbstractEventStateMachineTest extends TestCase
 
         // Expect subject to call the exception factory, mock result
         $subject->expects($this->once())
-                ->method('_createCouldNotTransitionException')
+                ->method('_createStateMachineException')
                 ->willReturn(new Exception());
 
         // Expect subject to invoke event manager's trigger method, which will throw an exception

--- a/test/unit/EventStateMachineTest.php
+++ b/test/unit/EventStateMachineTest.php
@@ -1,0 +1,586 @@
+<?php
+
+namespace RebelCode\State\UnitTest;
+
+use Dhii\Util\String\StringableInterface;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use RebelCode\State\EventStateMachine as TestSubject;
+use stdClass;
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class EventStateMachineTest extends TestCase
+{
+    /**
+     * The class name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\State\EventStateMachine';
+
+    /**
+     * The FQN of the event manager interface.
+     *
+     * @since [*next-version*]
+     */
+    const EVENT_MANAGER_INTERFACE = 'Psr\EventManager\EventManagerInterface';
+
+    /**
+     * The FQN of the transition event interface.
+     *
+     * @since [*next-version*]
+     */
+    const TRANSITION_EVENT_INTERFACE = 'Dhii\Events\TransitionEventInterface';
+
+    /**
+     * The FQN of the readable state machine interface.
+     *
+     * @since [*next-version*]
+     */
+    const READABLE_STATE_MACHINE_INTERFACE = 'Dhii\State\ReadableStateMachineInterface';
+
+    /**
+     * The FQN of the stringable interface.
+     *
+     * @since [*next-version*]
+     */
+    const STRINGABLE_INTERFACE = 'Dhii\Util\String\StringableInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $cArgs   The constructor args.
+     * @param array $methods The methods to mock.
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createInstance(array $cArgs = [], array $methods = [])
+    {
+        $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor();
+
+        if (!empty($methods)) {
+            $mock->setMethods($methods);
+        }
+
+        if (!empty($cArgs)) {
+            $mock->enableOriginalConstructor()
+                 ->setConstructorArgs($cArgs);
+        }
+
+        return $mock->getMockForAbstractClass();
+    }
+
+    /**
+     * Creates an event manager mock instance for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createEventManager()
+    {
+        $mock = $this->getMockBuilder(static::EVENT_MANAGER_INTERFACE)
+                     ->setMethods(
+                         [
+                             'attach',
+                             'detach',
+                             'trigger',
+                             'clearListeners',
+                         ]
+                     );
+
+        return $mock->getMock();
+    }
+
+    public function createTransitionEvent($name = '', $params = [], $target = null, $aborted = false)
+    {
+        return $this->mock(static::TRANSITION_EVENT_INTERFACE)
+                    ->getName($name)
+                    ->setName()
+                    ->getParams($params)
+                    ->setParams()
+                    ->getParam(
+                        function ($key) use ($params) {
+                            return array_key_exists($key, $params)
+                                ? $params[$key]
+                                : null;
+                        }
+                    )
+                    ->getTarget($target)
+                    ->setTarget()
+                    ->getTransition()
+                    ->stopPropagation()
+                    ->isPropagationStopped()
+                    ->abortTransition()
+                    ->isTransitionAborted($aborted)
+                    ->new();
+    }
+
+    /**
+     * Creates a mock stringable instance for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $string The string to return when the object is casted to string.
+     *
+     * @return StringableInterface
+     */
+    public function createStringable($string)
+    {
+        return $this->mock(static::STRINGABLE_INTERFACE)
+                    ->__toString($string)
+                    ->new();
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME,
+            $subject,
+            'A valid instance of the test subject could not be created.'
+        );
+
+        $this->assertInstanceOf(
+            static::READABLE_STATE_MACHINE_INTERFACE,
+            $subject,
+            'Test subject does not implement parent interface.'
+        );
+    }
+
+    /**
+     * Tests the constructor to ensure that all arguments are properly handled.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $evntMgr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+
+        $subject = $this->createInstance([$evntMgr, $state, $format, $target]);
+        $reflect = $this->reflect($subject);
+
+        $this->assertSame(
+            $evntMgr,
+            $reflect->_getEventManager(),
+            'Set and retrieved event managers are not the same.'
+        );
+        $this->assertSame(
+            $state,
+            $subject->getState(),
+            'Set and retrieved initial states are not the same.'
+        );
+        $this->assertSame(
+            $format,
+            $reflect->_getEventNameFormat(),
+            'Set and retrieved event name format are not the same.'
+        );
+        $this->assertSame(
+            $target,
+            $reflect->_getTarget(),
+            'Set and retrieved event target are not the same.'
+        );
+    }
+
+    /**
+     * Tests the event manager getter and setter methods.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetEventManager()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $reflect->_setEventManager($evtMngr = $this->createEventManager());
+
+        $this->assertSame(
+            $evtMngr,
+            $reflect->_getEventManager(),
+            'Set and retrieved target instances are not the same.'
+        );
+    }
+
+    /**
+     * Tests the event name format getter and setter methods.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetEventNameFormat()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $reflect->_setEventNameFormat($format = uniqid('%s-'));
+
+        $this->assertEquals(
+            $format,
+            $reflect->_getEventNameFormat(),
+            'Set and retrieved event name formats are not equal.'
+        );
+    }
+
+    /**
+     * Tests the event name format getter and setter methods with a null value.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetEventNameFormatNull()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $reflect->_setEventNameFormat(null);
+
+        $this->assertEquals(
+            TestSubject::DEFAULT_EVENT_NAME_FORMAT,
+            $reflect->_getEventNameFormat(),
+            'Set and retrieved event name formats are not equal.'
+        );
+    }
+
+    /**
+     * Tests the event name format getter and setter methods with an invalid value.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetEventNameFormatInvalid()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $this->setExpectedException('Dhii\Exception\InvalidArgumentException');
+
+        $reflect->_setEventNameFormat(new stdClass());
+    }
+
+    /**
+     * Tests the event target getter and setter methods.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetTarget()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $reflect->_setTarget($target = new stdClass());
+
+        $this->assertSame(
+            $target,
+            $reflect->_getTarget(),
+            'Set and retrieved target instances are not the same.'
+        );
+    }
+
+    /**
+     * Tests the string/stringable validation method.
+     *
+     * @since [*next-version*]
+     */
+    public function testIsValidString()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $string = uniqid('string-');
+        $stringable = $this->createStringable(uniqid('string-'));
+        $invalid = 108;
+        $invalidObj = new \stdClass();
+
+        $this->assertTrue($reflect->_isValidString($string), 'Strings should be valid.');
+        $this->assertTrue($reflect->_isValidString($stringable), 'Stringable instances should be valid.');
+        $this->assertFalse($reflect->_isValidString($invalid), 'Non-string values should be invalid');
+        $this->assertFalse($reflect->_isValidString($invalidObj), 'Non-stringable instances should be invalid');
+    }
+
+    /**
+     * Tests the transition event generator method.
+     *
+     * @since [*next-version*]
+     */
+    public function testCreateTransitionEvent()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $name = uniqid('event-');
+        $transition = $this->createStringable(uniqid('transition-'));
+        $target = new stdClass();
+        $params = [
+            'a' => 19,
+            'b' => uniqid('b-'),
+        ];
+
+        $this->assertInstanceOf(
+            static::TRANSITION_EVENT_INTERFACE,
+            $event = $reflect->_createTransitionEvent($name, $transition, $target, $params),
+            'Created event does not implement the transition-event interface'
+        );
+
+        $this->assertSame($name, $event->getName(), 'Event name is incorrect.');
+        $this->assertSame($transition, $event->getTransition(), 'Event transition is incorrect.');
+        $this->assertSame($target, $event->getTarget(), 'Event target is incorrect.');
+        $this->assertSame($params, $event->getParams(), 'Event params are incorrect.');
+    }
+
+    /**
+     * Tests the event parameters getter method.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetEventParams()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $params = $reflect->_getEventParams(uniqid('transition-'));
+
+        $this->assertArrayHasKey(TestSubject::K_PARAM_NEW_STATE, $params);
+        $this->assertArrayHasKey(TestSubject::K_PARAM_CURRENT_STATE, $params);
+    }
+
+    /**
+     * Tests the event name generator method.
+     *
+     * @since [*next-version*]
+     */
+    public function testGenerateEventName()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $subject = $this->createInstance([$evtMngr, $state, $format]);
+        $reflect = $this->reflect($subject);
+
+        $transition = uniqid('transition-');
+        $expected = sprintf($format, $transition);
+
+        $this->assertEquals(
+            $expected,
+            $reflect->_generateEventName($transition),
+            'Generated event name does not match expected name.'
+        );
+    }
+
+    /**
+     * Tests the transition event getter method to ensure that the retrieved event has correct data.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetTransitionEvent()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+        $subject = $this->createInstance([$evtMngr, $state, $format, $target], ['_getEventParams']);
+        $reflect = $this->reflect($subject);
+
+        // The transition
+        $transition = uniqid('transition-');
+
+        // Expect the event params method to be called
+        $subject->expects($this->once())
+                ->method('_getEventParams')
+                ->with($transition)
+                ->willReturn([]);
+
+        $event = $reflect->_getTransitionEvent($transition);
+
+        $this->assertInstanceOf(
+            static::TRANSITION_EVENT_INTERFACE,
+            $event,
+            'Retrieved event does not implement the expected interface.'
+        );
+        $this->assertEquals(
+            sprintf($format, $transition),
+            $event->getName(),
+            'Event name is incorrect.'
+        );
+        $this->assertSame(
+            $transition,
+            $event->getTransition(),
+            'Event\'s transition and transition given to method are not the same.'
+        );
+        $this->assertSame(
+            $target,
+            $event->getTarget(),
+            'Target set to instance and event\'s target are not the same.'
+        );
+    }
+
+    /**
+     * Tests the transition capability check method.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanTransition()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertTrue($subject->canTransition(uniqid('state-')));
+    }
+
+    /**
+     * Tests the transition method to ensure that the state in the returned machine is updated according to the event.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransition()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+        $subject = $this->createInstance([$evtMngr, $state, $format, $target], ['_getTransitionEvent']);
+
+        // Prepare transition event mock
+        $transition = uniqid('transition-');
+        $eventName = sprintf($format, $transition);
+        $newState = uniqid('new-state-');
+        $event = $this->createTransitionEvent($eventName, [TestSubject::K_PARAM_NEW_STATE => $newState]);
+
+        // Mock transition event retrieval
+        $subject->method('_getTransitionEvent')
+                ->willReturn($event);
+
+        // Expect event to be triggered by event manager
+        $evtMngr->expects($this->once())
+                ->method('trigger')
+                ->with($event);
+
+        $machine = $subject->transition($transition);
+
+        $this->assertSame(
+            $newState,
+            $machine->getState(),
+            'The machine\'s state was not correctly updated.'
+        );
+    }
+
+    /**
+     * Tests the transition method with an invalid new state in the event.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionInvalidNewState()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+        $subject = $this->createInstance([$evtMngr, $state, $format, $target], ['_getTransitionEvent']);
+
+        // Create transition event mock
+        $transition = uniqid('transition-');
+        $eventName = sprintf($format, $transition);
+        $newState = new stdClass();
+        $event = $this->createTransitionEvent($eventName, [TestSubject::K_PARAM_NEW_STATE => $newState]);
+
+        // Mock transition event retrieval
+        $subject->method('_getTransitionEvent')
+                ->willReturn($event);
+
+        // Expect exception since the new state is not valid
+        $this->setExpectedException('Dhii\State\Exception\CouldNotTransitionExceptionInterface');
+
+        $subject->transition($transition);
+    }
+
+    /**
+     * Tests the transition method with an exception thrown by an event handler.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionTriggerException()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+        $subject = $this->createInstance([$evtMngr, $state, $format, $target], ['_getTransitionEvent']);
+
+        // Prepare transition event mock
+        $transition = uniqid('transition-');
+        $eventName = sprintf($format, $transition);
+        $newState = uniqid('new-state-');
+        $event = $this->createTransitionEvent($eventName, [TestSubject::K_PARAM_NEW_STATE => $newState]);
+
+        // Mock transition event retrieval
+        $subject->method('_getTransitionEvent')
+                ->willReturn($event);
+
+        // Mock event manager trigger() method to throw an exception
+        $evtMngr->expects($this->once())
+                ->method('trigger')
+                ->willThrowException(new Exception());
+
+        // Expect the exception to be wrapped in a could-not-transition exception
+        $this->setExpectedException('Dhii\State\Exception\CouldNotTransitionExceptionInterface');
+
+        $subject->transition($transition);
+    }
+
+    /**
+     * Tests the transition method with an event that aborts the transition to ensure that the state does not change.
+     *
+     * @since [*next-version*]
+     */
+    public function testTransitionAbortTransition()
+    {
+        // Create test subject
+        $evtMngr = $this->createEventManager();
+        $state = uniqid('state-');
+        $format = uniqid('%s-');
+        $target = new stdClass();
+        $subject = $this->createInstance([$evtMngr, $state, $format, $target], ['_getTransitionEvent']);
+
+        // Mock transition event - will abort transition
+        $transition = uniqid('transition-');
+        $eventName = sprintf($format, $transition);
+        $newState = uniqid('new-state-');
+        $event = $this->createTransitionEvent(
+            $eventName,
+            [
+                TestSubject::K_PARAM_NEW_STATE => $newState,
+            ],
+            null, // target
+            true // aborted flag
+        );
+
+        // Mock transition event retrieval
+        $subject->method('_getTransitionEvent')
+                ->willReturn($event);
+
+        $machine = $subject->transition($transition);
+
+        $this->assertSame(
+            $state,
+            $machine->getState(),
+            'State should not have been updated; the transition was aborted.'
+        );
+    }
+}

--- a/test/unit/EventStateMachineTest.php
+++ b/test/unit/EventStateMachineTest.php
@@ -543,10 +543,16 @@ class EventStateMachineTest extends TestCase
                 ->method('trigger')
                 ->willThrowException(new Exception());
 
-        // Expect the exception to be wrapped in a could-not-transition exception
-        $this->setExpectedException('Dhii\State\Exception\CouldNotTransitionExceptionInterface');
+        // Expect the exception to be wrapped in a state machine exception
+        $this->setExpectedException('Dhii\State\Exception\StateMachineExceptionInterface');
 
-        $subject->transition($transition);
+        $machine = $subject->transition($transition);
+
+        $this->assertSame(
+            $transition,
+            $machine->getState(),
+            'The machine\'s state was not correctly updated.'
+        );
     }
 
     /**
@@ -571,6 +577,8 @@ class EventStateMachineTest extends TestCase
         // Mock transition event retrieval
         $subject->method('_getTransitionEvent')
                 ->willReturn($event);
+
+        $this->setExpectedException('Dhii\State\Exception\StateMachineExceptionInterface');
 
         $machine = $subject->transition($transition);
 

--- a/test/unit/Exception/CouldNotTransitionExceptionTest.php
+++ b/test/unit/Exception/CouldNotTransitionExceptionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace RebelCode\State\Exception\UnitTest;
+
+use Dhii\State\StateMachineInterface;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use Xpmock\TestCase;
+use RebelCode\State\Exception\CouldNotTransitionException as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class CouldNotTransitionExceptionTest extends TestCase
+{
+    /**
+     * The class name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\State\Exception\CouldNotTransitionException';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $cArgs   The constructor args.
+     * @param array $methods The methods to mock.
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createInstance(array $cArgs = [], array $methods = [])
+    {
+        $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor();
+
+        if (!empty($cArgs)) {
+            $mock->enableOriginalConstructor()
+                 ->setConstructorArgs($cArgs);
+        }
+        if (!empty($methods)) {
+            $mock->setMethods($methods);
+        }
+
+        return $mock->getMockForAbstractClass();
+    }
+
+    /**
+     * Creates a mocked state machine for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @return StateMachineInterface The state machine mock instance.
+     */
+    public function createStateMachine()
+    {
+        $mock = $this->mock('Dhii\State\StateMachineInterface')
+                     ->transition()
+                     ->canTransition();
+
+        return $mock->new();
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME,
+            $subject,
+            'A valid instance of the test subject could not be created.'
+        );
+    }
+
+    /**
+     * Tests the constructor to ensure that the arguments are correctly handled and that the instance is correctly
+     * initialized.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $message = uniqid('message-');
+        $code = rand(0, 100);
+        $previous = new Exception();
+        $stateMachine = $this->createStateMachine();
+        $transition = uniqid('transition-');
+        $subject = $this->createInstance([$message, $code, $previous, $stateMachine, $transition]);
+
+        $this->assertSame(
+            $message,
+            $subject->getMessage(),
+            'Set and retrieved messages are not the same.'
+        );
+        $this->assertSame(
+            $code,
+            $subject->getCode(),
+            'Set and retrieved code are not the same.'
+        );
+        $this->assertSame(
+            $previous,
+            $subject->getPrevious(),
+            'Set and retrieved previous exception are not the same.'
+        );
+        $this->assertSame(
+            $stateMachine,
+            $subject->getStateMachine(),
+            'Set and retrieved state machines are not the same.'
+        );
+        $this->assertSame(
+            $transition,
+            $subject->getTransition(),
+            'Set and retrieved transitions are not the same.'
+        );
+    }
+}

--- a/test/unit/Exception/StateMachineExceptionTest.php
+++ b/test/unit/Exception/StateMachineExceptionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace RebelCode\State\Exception\UnitTest;
+
+use Dhii\State\StateMachineInterface;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use Xpmock\TestCase;
+use RebelCode\State\Exception\StateMachineException as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class StateMachineExceptionTest extends TestCase
+{
+    /**
+     * The class name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\State\Exception\StateMachineException';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $cArgs   The constructor args.
+     * @param array $methods The methods to mock.
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createInstance(array $cArgs = [], array $methods = [])
+    {
+        $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor();
+
+        if (!empty($cArgs)) {
+            $mock->enableOriginalConstructor()
+                 ->setConstructorArgs($cArgs);
+        }
+        if (!empty($methods)) {
+            $mock->setMethods($methods);
+        }
+
+        return $mock->getMockForAbstractClass();
+    }
+
+    /**
+     * Creates a mocked state machine for testing purposes.
+     *
+     * @since [*next-version*]
+     *
+     * @return StateMachineInterface The state machine mock instance.
+     */
+    public function createStateMachine()
+    {
+        $mock = $this->mock('Dhii\State\StateMachineInterface')
+                     ->transition()
+                     ->canTransition();
+
+        return $mock->new();
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME,
+            $subject,
+            'A valid instance of the test subject could not be created.'
+        );
+    }
+
+    /**
+     * Tests the constructor to ensure that the arguments are correctly handled and that the instance is correctly
+     * initialized.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $message = uniqid('message-');
+        $code = rand(0, 100);
+        $previous = new Exception();
+        $stateMachine = $this->createStateMachine();
+        $subject = $this->createInstance([$message, $code, $previous, $stateMachine]);
+
+        $this->assertSame(
+            $message,
+            $subject->getMessage(),
+            'Set and retrieved messages are not the same.'
+        );
+        $this->assertSame(
+            $code,
+            $subject->getCode(),
+            'Set and retrieved code are not the same.'
+        );
+        $this->assertSame(
+            $previous,
+            $subject->getPrevious(),
+            'Set and retrieved previous exception are not the same.'
+        );
+        $this->assertSame(
+            $stateMachine,
+            $subject->getStateMachine(),
+            'Set and retrieved state machines are not the same.'
+        );
+    }
+}

--- a/test/unit/TransitionEventTest.php
+++ b/test/unit/TransitionEventTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace RebelCode\State\UnitTest;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use stdClass;
+use Xpmock\TestCase;
+use RebelCode\State\TransitionEvent as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class TransitionEventTest extends TestCase
+{
+    /**
+     * The class name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\State\TransitionEvent';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $cArgs   The constructor arguments.
+     * @param array $methods The methods to mock.
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    public function createInstance(array $cArgs = [], array $methods = [])
+    {
+        $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor();
+
+        if (!empty($methods)) {
+            $mock->setMethods($methods);
+        }
+        if (!empty($cArgs)) {
+            $mock->enableOriginalConstructor()
+                 ->setConstructorArgs($cArgs);
+        }
+
+        return $mock->getMockForAbstractClass();
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME,
+            $subject,
+            'A valid instance of the test subject could not be created.'
+        );
+    }
+
+    /**
+     * Tests the constructor to ensure that the arguments are correctly handled and that the instance is correctly
+     * initialized.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $name = uniqid('name-');
+        $transition = uniqid('transition-');
+        $target = new stdClass();
+        $params = [
+            uniqid('key-') => uniqid('value-'),
+        ];
+
+        $subject = $this->createInstance([$name, $transition, $target, $params]);
+
+        $this->assertSame($name, $subject->getName(), 'Set and retrieved names are not the same.');
+        $this->assertSame($transition, $subject->getTransition(), 'Set and retrieved transitions are not the same.');
+        $this->assertSame($target, $subject->getTarget(), 'Set and retrieved targets are not the same.');
+        $this->assertSame($params, $subject->getParams(), 'Set and retrieved params are not the same.');
+        $this->assertFalse($subject->isPropagationStopped(), 'Propagation should initially be false.');
+    }
+
+    /**
+     * Tests the name getter and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetName()
+    {
+        $subject = $this->createInstance();
+
+        $subject->setName($name = uniqid('name-'));
+
+        $this->assertSame($name, $subject->getName(), 'Set and retrieved names are not the same.');
+    }
+
+    /**
+     * Tests the target getter and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetTarget()
+    {
+        $subject = $this->createInstance();
+
+        $subject->setTarget($target = new stdClass());
+
+        $this->assertSame($target, $subject->getTarget(), 'Set and retrieved targets are not the same.');
+    }
+
+    /**
+     * Tests the transition getter and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetTransition()
+    {
+        $subject = $this->createInstance();
+        $reflect = $this->reflect($subject);
+
+        $reflect->_setTransition($transition = uniqid('transition-'));
+
+        $this->assertSame($transition, $subject->getTransition(), 'Set and retrieved transitions are not the same.');
+    }
+
+    /**
+     * Tests the propagation getter and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testSetIsPropagationStopped()
+    {
+        $subject = $this->createInstance();
+
+        $subject->stopPropagation(true);
+        $this->assertTrue($subject->isPropagationStopped(), 'Propagation should be stopped.');
+
+        $subject->stopPropagation(false);
+        $this->assertFalse($subject->isPropagationStopped(), 'Propagation should not be stopped.');
+    }
+
+    /**
+     * Tests the params getter and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetSetParams()
+    {
+        $subject = $this->createInstance();
+
+        $subject->setParams(
+            $params = [
+                $key1 = uniqid('key1-') => $value1 = uniqid('value-1'),
+                $key2 = uniqid('key2-') => $value2 = uniqid('value-2'),
+                $key3 = uniqid('key3-') => $value3 = uniqid('value-3'),
+            ]
+        );
+        $key4 = uniqid('key4-');
+
+        $this->assertEquals(
+            $params,
+            $subject->getParams(),
+            'Set and retrieved params are not the same.',
+            0.0, // delta
+            10,  // depth
+            true // canonical flag
+        );
+
+        $this->assertEquals($value1, $subject->getParam($key1), 'Param value is incorrect.');
+        $this->assertEquals($value2, $subject->getParam($key2), 'Param value is incorrect.');
+        $this->assertEquals($value3, $subject->getParam($key3), 'Param value is incorrect.');
+        $this->assertNull($subject->getParam($key4), 'Expected null value for non-existing param.');
+    }
+
+    /**
+     * Tests the transition checker and setter methods to ensure correct value assignment and retrieval.
+     *
+     * @since [*next-version*]
+     */
+    public function testSetIsTransitionAborted()
+    {
+        $subject = $this->createInstance();
+
+        $subject->abortTransition(true);
+        $this->assertTrue($subject->isTransitionAborted(), 'Transition should be aborted.');
+
+        $subject->abortTransition(false);
+        $this->assertFalse($subject->isTransitionAborted(), 'Transition should not be aborted.');
+    }
+}


### PR DESCRIPTION
Initial classes for a basic event-driven state machine implementation.

The machine uses an event manager to trigger events on transition. A specialized `TransitionEvent` instance is given to the event manager. Handlers can use the event to abort transitions ~and also specify the new state of the machine.~ The transition key is used as the new state, unless the transition is aborted.

If an exception is thrown, the transition will still happen. Event handlers will need to catch exceptions and explicitly abort the transition.